### PR TITLE
PHP 7.4 and deprecation notices

### DIFF
--- a/src/main/php/NewInstance.php
+++ b/src/main/php/NewInstance.php
@@ -345,7 +345,7 @@ class NewInstance
     private static function detectReturnType(\ReflectionMethod $method): ?string
     {
         if ($method->hasReturnType()) {
-            return (string) $method->getReturnType();
+            return $method->getReturnType()->getName();
         }
 
         $docComment = $method->getDocComment();

--- a/src/main/php/functions.php
+++ b/src/main/php/functions.php
@@ -78,10 +78,10 @@ namespace bovigo\callmap {
         }
 
         if ($returnType->isBuiltin()) {
-            return ': ' . $returnType;
+            return ': ' . $returnType->getName();
         }
 
-        if ('self' == $returnType) {
+        if ('self' == $returnType->getName()) {
             if ($function instanceof \ReflectionMethod) {
                 return ': \\' . $function->getDeclaringClass()->getName();
             }
@@ -89,7 +89,7 @@ namespace bovigo\callmap {
             throw new \UnexpectedValueException('Function ' . $function->getName() . ' defines return type self but that is not possible.');
         }
 
-        return ': \\' . $returnType;
+        return ': \\' . $returnType->getName();
     }
 
     /**
@@ -112,7 +112,7 @@ namespace bovigo\callmap {
             } elseif ($parameter->isCallable()) {
                 $param .= 'callable ';
             } elseif ($parameter->hasType()) {
-                $param .= $parameter->getType() . ' ';
+                $param .= $parameter->getType()->getName() . ' ';
             }
 
             if ($parameter->isPassedByReference()) {


### PR DESCRIPTION
[ReflectionType::__toString](https://www.php.net/manual/en/reflectiontype.tostring.php) issues deprecation notice in 7.4, switched to [ReflectionNamedType::getName](https://www.php.net/manual/en/reflectionnamedtype.getname.php).

Strangely enough, no deprecation notices were issued in tests of this library itself, but you can see them bubble up within https://github.com/bovigo/vfsStream/pull/189