### PR TITLE
Fix PHPUnit fixtures

### DIFF
--- a/src/test/php/AbstractMethodTest.php
+++ b/src/test/php/AbstractMethodTest.php
@@ -25,7 +25,7 @@ class AbstractMethodTest extends TestCase
      */
     private $proxy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::of(Instrument::class);
     }

--- a/src/test/php/InternalClassTest.php
+++ b/src/test/php/InternalClassTest.php
@@ -23,7 +23,7 @@ class InternalClassTest extends TestCase
      */
     private $proxy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::of(\ReflectionObject::class, [$this]);
     }

--- a/src/test/php/InternalInterfaceTest.php
+++ b/src/test/php/InternalInterfaceTest.php
@@ -24,7 +24,7 @@ class InternalInterfaceTest extends TestCase
      */
     private $proxy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::of(\Countable::class);
     }

--- a/src/test/php/InvocationResultsTest.php
+++ b/src/test/php/InvocationResultsTest.php
@@ -25,7 +25,7 @@ class InvocationResultsTest extends TestCase
      */
     private $proxy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::of(\ReflectionObject::class, [$this]);
     }

--- a/src/test/php/NewCallableParseErrorTest.php
+++ b/src/test/php/NewCallableParseErrorTest.php
@@ -20,12 +20,12 @@ use function bovigo\assert\expect;
  */
 class NewCallableParseErrorTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         NewCallable::$compile = function() { throw new \ParseError('failed to evaluate'); };
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         NewCallable::$compile = __NAMESPACE__ . '\compile';
     }

--- a/src/test/php/NewInstanceParseErrorTest.php
+++ b/src/test/php/NewInstanceParseErrorTest.php
@@ -21,12 +21,12 @@ use function bovigo\assert\expect;
  */
 class NewInstanceParseErrorTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         NewInstance::$compile = function() { throw new \ParseError('failed to evaluate'); };
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
         NewInstance::$compile = __NAMESPACE__ . '\compile';
     }

--- a/src/test/php/ReturnSelfPhp7Test.php
+++ b/src/test/php/ReturnSelfPhp7Test.php
@@ -31,7 +31,7 @@ class ReturnSelfPhp7Test extends TestCase
      */
     private $proxy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::stub(Extended7::class);
     }

--- a/src/test/php/ReturnSelfTest.php
+++ b/src/test/php/ReturnSelfTest.php
@@ -35,7 +35,7 @@ class ReturnSelfTest extends TestCase
      */
     private $proxy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::stub(Extended::class);
     }

--- a/src/test/php/SelfDefinedClassTest.php
+++ b/src/test/php/SelfDefinedClassTest.php
@@ -25,7 +25,7 @@ class SelfDefinedClassTest extends TestCase
      */
     private $proxy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::of(new SelfDefined());
     }

--- a/src/test/php/ThrowsTest.php
+++ b/src/test/php/ThrowsTest.php
@@ -25,7 +25,7 @@ class ThrowsTest extends TestCase
      */
     private $proxy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::of(\ReflectionObject::class, [$this]);
     }

--- a/src/test/php/TraitTest.php
+++ b/src/test/php/TraitTest.php
@@ -28,7 +28,7 @@ class TraitTest extends TestCase
      */
     private $proxy;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::of(SomeTrait::class);
     }

--- a/src/test/php/VerificationWithPhpUnitTest.php
+++ b/src/test/php/VerificationWithPhpUnitTest.php
@@ -24,7 +24,7 @@ class VerificationWithPhpUnitTest extends TestCase
      */
     private $phpUnitVerification;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->phpUnitVerification = new class(new Invocations('', [])) extends Verification
         {

--- a/src/test/php/VerificationWithXpFrameworkCoreTest.php
+++ b/src/test/php/VerificationWithXpFrameworkCoreTest.php
@@ -26,7 +26,7 @@ class VerificationWithXpFrameworkCoreTest extends TestCase
      */
     private $xpFrameworkCoreVerification;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->xpFrameworkCoreVerification = new class(new Invocations('', [])) extends Verification
         {

--- a/src/test/php/VerifyClassProxyTest.php
+++ b/src/test/php/VerifyClassProxyTest.php
@@ -32,7 +32,7 @@ class VerifyClassProxyTest extends TestCase
     /**
      * set up test environment
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::of(Verified::class);
     }

--- a/src/test/php/WithoutConstructorTest.php
+++ b/src/test/php/WithoutConstructorTest.php
@@ -28,7 +28,7 @@ class WithoutConstructorTest extends TestCase
     /**
      * set up test environment
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->proxy = NewInstance::stub(ClassWithConstructor::class);
     }


### PR DESCRIPTION
# Changed log
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/9.0/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void`.